### PR TITLE
battery remaining extension causes conflicts with other extensions

### DIFF
--- a/battery-remaining-time@dadexix86.github.com/extension.js
+++ b/battery-remaining-time@dadexix86.github.com/extension.js
@@ -200,6 +200,10 @@ function monkeypatch(batteryArea) {
             else
                 arrow = ' ';
 
+            if (!this._withLabel) {
+                this._replaceIconWithBox();
+            }
+
             if (totalMatch[2] == 1){
                 if(!showOnCharge)
                     hideBattery();
@@ -266,10 +270,6 @@ function monkeypatch(batteryArea) {
             if (debug){
                 global.log("displayString:" + this.displayString.toString());
             }
-
-            if (!this._withLabel) {
-                this._replaceIconWithBox();
-            }
             
             this._label.set_text(this.displayString);
         }));
@@ -280,8 +280,12 @@ function hideBattery() {
     for (var i = 0; i < Main.panel._rightBox.get_children().length; i++) {
         if (Main.panel.statusArea['battery'] == 
             Main.panel._rightBox.get_children()[i]._delegate ||
-            Main.panel.statusArea['batteryBox'] == 
-            Main.panel._rightBox.get_children()[i]._delegate) {
+	    (
+	     Main.panel.statusArea['batteryBox'] != undefined &&
+	     Main.panel.statusArea['batteryBox'] == 
+	     Main.panel._rightBox.get_children()[i]._delegate
+	    )
+	   ) {
             if (debug){
                 global.log("Battery Remaing Time: hiding battery.");
             }
@@ -295,8 +299,12 @@ function showBattery() {
     for (var i = 0; i < Main.panel._rightBox.get_children().length; i++) {
         if (Main.panel.statusArea['battery'] == 
             Main.panel._rightBox.get_children()[i]._delegate ||
-            Main.panel.statusArea['batteryBox'] == 
-            Main.panel._rightBox.get_children()[i]._delegate) {
+	    (
+	     Main.panel.statusArea['batteryBox'] != undefined &&
+             Main.panel.statusArea['batteryBox'] == 
+             Main.panel._rightBox.get_children()[i]._delegate
+	    )
+	   ) {
             if (debug){
                 global.log("Battery Remaing Time: showing battery.");
             }


### PR DESCRIPTION
It appears that this extension is conflicting with the GPaste extension, and possibly others. See the following bug from GPaste https://github.com/Keruspe/GPaste/issues/51

After investigating, I found that if the batteryBox has not been created when hideBattery() or showBattery() is called, matching Main.panel.statusArea['batteryBox'] to Main.panel._rightBox.get_children()[i]._delegate will succeed for every extension. I've moved the call to the _replaceIconWithBox() call to come before the hideBattery() and showBattery() calls. I've also added a check to each of those functions to ensure that Main.panel.statusArea['batteryBox'] is not undefined before comparing to the _delegate property.
